### PR TITLE
Включил CROSS для поддержки ангуляра

### DIFF
--- a/src/main/java/com/example/libraryserver/конфиг/ConfigWeb.java
+++ b/src/main/java/com/example/libraryserver/конфиг/ConfigWeb.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
-public class КонфигВеб implements WebMvcConfigurer {
+public class ConfigWeb implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/com/example/libraryserver/конфиг/КонфигВеб.java
+++ b/src/main/java/com/example/libraryserver/конфиг/КонфигВеб.java
@@ -1,0 +1,14 @@
+package com.example.libraryserver.конфиг;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+@Configuration
+public class КонфигВеб implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE");
+    }
+}


### PR DESCRIPTION
Ошибку вызывает то, что ангуляр обращается к спрингу, который запущен на том же устройстве.
По сути просто в конфиги разрешил такой тип запросов. По большей части паше полезен будет.
Почему постман эту ошибку не дает я понятия не имею, видимо не просто так он создан и работает.
![IMG_20200504_211031](https://github.com/MacosTacos/LibraryServer/assets/79145526/14ac8bc9-c774-4ef4-9839-5a1a8ff515b2)
